### PR TITLE
Love12 support

### DIFF
--- a/conf.lua
+++ b/conf.lua
@@ -1,7 +1,7 @@
 function love.conf(t)
     t.window.width = 960
     t.window.height = 480
-    if love._version_major >= 12 then
+    if love._version_major > 11 then
         t.window.depth = true
     else
         t.window.depth = 24

--- a/conf.lua
+++ b/conf.lua
@@ -1,8 +1,11 @@
 function love.conf(t)
     t.window.width = 960
     t.window.height = 480
-
-    t.window.depth = 24
+    if love._version_major >= 12 then
+        t.window.depth = true
+    else
+        t.window.depth = 24
+    end
     t.window.title = "Menori Examples"
     t.window.vsync = true
     t.highdpi = true

--- a/examples/SSAO/ssao.glsl
+++ b/examples/SSAO/ssao.glsl
@@ -17,7 +17,6 @@ uniform mat4 inv_projection;
 // reconstruct the view space positions of pixels from the depth buffer
 vec3 get_position(vec2 uv) {
     float z = Texel(depth24_c, uv).r * 2.0 - 1.0;
-    //z *= -1;
     vec4 clipSpacePosition = vec4(uv * 2.0 - 1.0, z, 1.0);
     vec4 viewSpacePosition = inv_projection * clipSpacePosition;
     viewSpacePosition /= viewSpacePosition.w;

--- a/examples/SSAO/ssao.glsl
+++ b/examples/SSAO/ssao.glsl
@@ -17,6 +17,7 @@ uniform mat4 inv_projection;
 // reconstruct the view space positions of pixels from the depth buffer
 vec3 get_position(vec2 uv) {
     float z = Texel(depth24_c, uv).r * 2.0 - 1.0;
+    //z *= -1;
     vec4 clipSpacePosition = vec4(uv * 2.0 - 1.0, z, 1.0);
     vec4 viewSpacePosition = inv_projection * clipSpacePosition;
     viewSpacePosition /= viewSpacePosition.w;

--- a/menori/modules/core3d/environment.lua
+++ b/menori/modules/core3d/environment.lua
@@ -56,7 +56,10 @@ function Environment:send_uniforms_to(shader)
 
 	local render_to_canvas = love.graphics.getCanvas() ~= nil
 	temp_projection_m:copy(camera.m_projection)
-	if render_to_canvas then temp_projection_m[6] = -temp_projection_m[6] end
+
+	if love._version_major <= 11 and render_to_canvas then
+		temp_projection_m[6] = -temp_projection_m[6]
+	end
 
 	shader:send("m_view", 'column', camera.m_view.data)
 	shader:send("m_projection", 'column', temp_projection_m.data)

--- a/menori/modules/core3d/gltf.lua
+++ b/menori/modules/core3d/gltf.lua
@@ -105,7 +105,7 @@ local attribute_aliases = {
 
 local function get_primitive_modes_constants(mode)
 	if mode == 0 then
-		return 'points'
+		return 'vertices'
 	elseif mode == 1 then
 	elseif mode == 2 then
 	elseif mode == 3 then
@@ -515,10 +515,19 @@ local function load_image(io_read, path, images, texture)
 		image_data = love.image.newCompressedData(image_raw_data)
 	end
 
-	local image_source = love.graphics.newImage(image_data)
+	local image_source
+	if love._version_major >= 12 then
+		image_source = love.graphics.newTexture(image_data, {
+			debugname = image.name,
+			linear = true,
+			mipmaps = true,
+		})
+	else
+		image_source = love.graphics.newImage(image_data)
+	end
 	image_data:release()
 	return {
-		source = image_source
+		source = image_source,
 	}
 end
 

--- a/menori/modules/core3d/gltf.lua
+++ b/menori/modules/core3d/gltf.lua
@@ -430,7 +430,7 @@ local function parse_wrap(value)
 	value == 10497 then
 		return 'repeat'
 	else
-		return 'clamp'
+		return 'repeat'
 	end
 end
 

--- a/menori/modules/core3d/gltf.lua
+++ b/menori/modules/core3d/gltf.lua
@@ -516,7 +516,7 @@ local function load_image(io_read, path, images, texture)
 	end
 
 	local image_source
-	if love._version_major >= 12 then
+	if love._version_major > 11 then
 		image_source = love.graphics.newTexture(image_data, {
 			debugname = image.name,
 			linear = true,

--- a/menori/modules/core3d/gltf.lua
+++ b/menori/modules/core3d/gltf.lua
@@ -527,7 +527,7 @@ local function load_image(io_read, path, images, texture)
 	end
 	image_data:release()
 	return {
-		source = image_source,
+		source = image_source
 	}
 end
 

--- a/menori/modules/core3d/mesh.lua
+++ b/menori/modules/core3d/mesh.lua
@@ -115,7 +115,7 @@ end
 -- @tparam table format Vertex format table.
 function Mesh.get_attribute_index(attribute, format)
       for i, v in ipairs(format) do
-            if v[1] == attribute then
+            if v[1] == attribute or v.name == attribute then
                   return i
             end
       end


### PR DESCRIPTION
When running the library with a recent build of love12 it wasn't working. These changes are targeted at making it work, including all the examples running the same as they would in love11. I tried to keep the impact of these changes low, following the formatting of the rest of the project. Changes to `gltf.lua` was submitted by @JasperKr, and shorted to their relevant changes by myself.

I've tested this in love 11.5 (official release) and love 12, [this build](https://github.com/love2d/love/actions/runs/10150747778)

It's important to note, I've only tested with the examples given and not used a dedicated test bench of every single feature.