### PR TITLE
Small memory optimizations

### DIFF
--- a/menori/modules/core3d/gltf_animations.lua
+++ b/menori/modules/core3d/gltf_animations.lua
@@ -32,24 +32,29 @@ function glTFAnimation:init(animations)
 	self.animation = self.animations[1]
 end
 
+
+local q_a, q_b = quat(), quat()
+local v_a, v_b = vec3(), vec3()
 local function get_sampler_data(accumulator, sampler, target)
 	local min = sampler.time_array[1]
 	local max = sampler.time_array[#sampler.time_array]
 	accumulator = (accumulator % (max - min)) + min
 
+
 	local frame1_index = utils.binsearch(sampler.time_array, accumulator)
 	local frame2_index = math.min(#sampler.time_array, frame1_index + 1)
+
 
 	local frame1 = sampler.data_array[frame1_index]
 	local frame2 = sampler.data_array[frame2_index]
 
 	if sampler.interpolation == 'STEP' or frame1_index == frame2_index then
 		if target == 'rotation' then
-			return quat(frame1)
+			return q_a:set(frame1)
 		elseif target == 'weights' then
 
 		else
-			return vec3(frame1)
+			return v_a:set(frame1)
 		end
 	end
 
@@ -60,11 +65,11 @@ local function get_sampler_data(accumulator, sampler, target)
 
 	if sampler.interpolation == 'LINEAR' then
 		if target == 'rotation' then
-			return quat.slerp(quat(frame1), quat(frame2), s)
+			return quat.slerp(q_a:set(frame1), q_b:set(frame2), s)
 		elseif target == 'weights' then
 
 		else
-			return vec3.lerp(vec3(frame1), vec3(frame2), s)
+			return vec3.lerp(v_a:set(frame1), v_b:set(frame2), s)
 		end
 	end
 
@@ -117,6 +122,7 @@ function glTFAnimation:update(dt)
 		end
 	end
 	self.accumulator = self.accumulator + dt
+
 end
 
 return glTFAnimation

--- a/menori/modules/node.lua
+++ b/menori/modules/node.lua
@@ -92,7 +92,7 @@ end
 -- @tparam ml.quat q Rotation quaternion.
 function Node:set_rotation(q)
       self._transform_flag = true
-      self.rotation = q
+      self.rotation:set(q)
 end
 
 --- Set Node local scale.


### PR DESCRIPTION
This PR consists of 3 changes
- using file local quaternions for blending animation data to relieve gc pressure, it created 90KiB+ garbage per frame in the default example 
  
- changing node:set_rotation to to use rotation:set q instead of rotation = q to make it work like the set_position and set_scale siblings

- storing skinning imagebuffers on the model and using ImageData directly instead of converting it from byte data
this solves hitches and recreating large amounts of data, which improved framerates a lot on my system, 
i fear that the non-ffi path might penalize web with the 4 function calls but this version is also compatible with 11, might be an ok tradeoff

